### PR TITLE
fix broken doc.rs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::all)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Core modules
 mod result;


### PR DESCRIPTION
The 0.1.20 build on docs.rs for pipex is broken because the doc_cfg feature isn't enabled:
```
[INFO] [stderr]  Documenting pipex v0.1.20 (/opt/rustwide/workdir)
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]   --> src/lib.rs:27:20
[INFO] [stderr]    |
[INFO] [stderr] 27 | #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
[INFO] [stderr]    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]    |
[INFO] [stderr]    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
[INFO] [stderr]    = note: this compiler was built on 2025-09-01; consider upgrading it if it is out of date
[INFO] [stderr] 
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]   --> src/lib.rs:31:20
[INFO] [stderr]    |
[INFO] [stderr] 31 | #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
[INFO] [stderr]    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]    |
[INFO] [stderr]    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
[INFO] [stderr]    = note: this compiler was built on 2025-09-01; consider upgrading it if it is out of date
[INFO] [stderr] 
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]   --> src/lib.rs:35:20
[INFO] [stderr]    |
[INFO] [stderr] 35 | #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
[INFO] [stderr]    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]    |
[INFO] [stderr]    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
[INFO] [stderr]    = note: this compiler was built on 2025-09-01; consider upgrading it if it is out of date
[INFO] [stderr] 
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]   --> src/lib.rs:39:20
[INFO] [stderr]    |
[INFO] [stderr] 39 | #[cfg_attr(docsrs, doc(cfg(feature = "memoization")))]
[INFO] [stderr]    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]    |
[INFO] [stderr]    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
[INFO] [stderr]    = note: this compiler was built on 2025-09-01; consider upgrading it if it is out of date
[INFO] [stderr] 
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]   --> src/lib.rs:43:20
[INFO] [stderr]    |
[INFO] [stderr] 43 | #[cfg_attr(docsrs, doc(cfg(feature = "memoization")))]
[INFO] [stderr]    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]    |
[INFO] [stderr]    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
[INFO] [stderr]    = note: this compiler was built on 2025-09-01; consider upgrading it if it is out of date
[INFO] [stderr] 
[INFO] [stderr] For more information about this error, try `rustc --explain E0658`.
[INFO] [stderr] error: could not document `pipex`
```
This change enables that feature on docs.rs and should fix the build errors.